### PR TITLE
fix online notify connect error

### DIFF
--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/cache/DataServerCache.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/cache/DataServerCache.java
@@ -25,6 +25,7 @@ import com.alipay.sofa.registry.server.data.event.DataServerChangeEvent.FromType
 import com.alipay.sofa.registry.server.data.event.handler.AfterWorkingProcessHandler;
 import com.alipay.sofa.registry.server.data.node.DataNodeStatus;
 import com.alipay.sofa.registry.server.data.util.LocalServerStatusEnum;
+import com.google.common.collect.Sets;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collection;
@@ -249,13 +250,15 @@ public class DataServerCache {
             Map<String, LocalServerStatusEnum> map = nodeStatusMap.get(curVersion.get());
             if (map != null) {
                 Set<String> ips = map.keySet();
-                if (!ips.containsAll(newDataServerChangeItem.getServerMap()
-                    .get(dataServerConfig.getLocalDataCenter()).keySet())) {
-                    LOGGER.info(
-                        "nodeStatusMap not contains all push list,nodeStatusMap {} push {}",
-                        nodeStatusMap,
-                        newDataServerChangeItem.getServerMap()
-                            .get(dataServerConfig.getLocalDataCenter()).keySet());
+                Set<String> itemIps = newDataServerChangeItem.getServerMap()
+                    .get(dataServerConfig.getLocalDataCenter()).keySet();
+                if (!ips.containsAll(itemIps)) {
+
+                    LOGGER
+                        .info(
+                            "nodeStatusMap not contains all push list,nodeStatusMap {},push {},diff1{},diff2{}",
+                            nodeStatusMap, itemIps, Sets.difference(ips, itemIps),
+                            Sets.difference(itemIps, ips));
                     return;
                 }
             } else {

--- a/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/event/handler/DataServerChangeEventHandler.java
+++ b/server/server/data/src/main/java/com/alipay/sofa/registry/server/data/event/handler/DataServerChangeEventHandler.java
@@ -189,6 +189,9 @@ public class DataServerChangeEventHandler extends AbstractEventHandler<DataServe
                         "[DataServerChangeEventHandler] connect dataserver %s in %s failed five times,dataServer will not work,please check connect!",
                         ip, dataCenter));
         }
+        LOGGER.info(
+            "[DataServerChangeEventHandler] connect dataserver in {} success,remote={},local={}",
+            dataCenter, conn.getRemoteAddress(), conn.getLocalAddress());
         //maybe get dataNode from metaServer,current has not start! register dataNode info to factory,wait for connect task next execute
         DataServerNodeFactory.register(new DataServerNode(ip, dataCenter, conn), dataServerConfig);
     }


### PR DESCRIPTION
Fixes

The dataserver needs to reach the working state, several necessary conditions: its own state needs to notify other nodes to know; other data node states must be synchronized to the current node to know; in the case of other nodes with data, you need to synchronize the data own data. .

In this case, due to the increase in the number of machines, the probability of failure to link other machines increases, so that notifications that inform other machines of the current machine status may not be successfully sent, and it is necessary to wait for the link to retry before completing.

The previous code notifies other nodes that there is a bug in the link information code, which makes it impossible to notify that the loop has been notified with a failed link, so the working cannot be completed.